### PR TITLE
feat: Adding basic accessibility out of the box

### DIFF
--- a/example/src/SegmentedControl.tsx
+++ b/example/src/SegmentedControl.tsx
@@ -194,8 +194,12 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
         ]}
       />
       {segments.map((segment, index) => {
+        const accessibilityHint = currentIndex !== index ? `Selects ${segment} option` : ""
         return (
           <Pressable
+            accessibilityState={{ selected: currentIndex === index }}
+            accessibilityHint={accessibilityHint}
+            accessibilityLabel={`${segment} option ${index + 1} of ${segments.length}`}
             onPress={() => memoizedTabPressCallback(index)}
             key={index}
             style={[styles.touchableContainer, pressableWrapper]}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -194,8 +194,12 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
         ]}
       />
       {segments.map((segment, index) => {
+        const accessibilityHint = currentIndex !== index ? `Selects ${segment} option` : ""
         return (
           <Pressable
+            accessibilityState={{ selected: currentIndex === index }}
+            accessibilityHint={accessibilityHint}
+            accessibilityLabel={`${segment} option ${index + 1} of ${segments.length}`}
             onPress={() => memoizedTabPressCallback(index)}
             key={index}
             style={[styles.touchableContainer, pressableWrapper]}


### PR DESCRIPTION
Currently, **react-native-segmented-control** is not accessible and neither export some props to add labels or hints on text and badges, this small PR adds very very basic accessibility out of the box.