### PR TITLE
fix: badge value of `0` crash

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -210,7 +210,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
               >
                 {segment}
               </Text>
-              {badgeValues[index] && (
+              {typeof badgeValues[index] === 'number' && (
                 <View
                   style={[
                     styles.defaultBadgeContainerStyle,


### PR DESCRIPTION
If one of the badge values was `0`, it would cause a crash because it would try to render the `0` outside of a `Text` component.

The code also didn't allow for a badge with `0` to be rendered in the first place.

This fixes that by checking if the type of the badge value is a `number`, instead of checking if it's _truthy_.