### PR TITLE
feat: Segment accessibility

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -127,6 +127,14 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
   const translateValue = width / segments.length;
   const tabTranslateValue = useSharedValue(0);
 
+  // Transform and memoize all segments into a `Segment` array.
+  // This allows for the segments to be transformed only when they change, and to be treated as `Segment` on render.
+  const memoizedSegments = React.useMemo<Segment[]>(() => {
+    return segments.map((segment) =>
+      typeof segment === 'string' ? { label: segment } : segment
+    );
+  }, [segments]);
+
   // useCallBack with an empty array as input, which will call inner lambda only once and memoize the reference for future calls
   const memoizedTabPressCallback = React.useCallback(
     (index) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -228,6 +228,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
               segments.length
             }`}
             accessibilityRole="button"
+            {...accessibilityProps}
           >
             <View style={styles.textWrapper}>
               <Text

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect } from 'react';
 import {
+  AccessibilityRole,
+  AccessibilityState,
+  AccessibilityValue,
   Pressable,
   StyleSheet,
   Text,
@@ -14,11 +17,20 @@ import Animated, {
 } from 'react-native-reanimated';
 import { widthPercentageToDP } from 'react-native-responsive-screen';
 
-interface SegmentedControlProps {
+export interface Segment {
+  label: string;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  accessibilityRole?: AccessibilityRole;
+  accessibilityState?: AccessibilityState;
+  accessibilityValue?: AccessibilityValue;
+}
+
+export interface SegmentedControlProps {
   /**
-   * The Segments Text Array
+   * An array of Segments. Can be a mix of strings for the Segment labels, or an object with a `label` and accessibility props.
    */
-  segments: Array<string>;
+  segments: Array<string | Segment>;
   /**
    * The Current Active Segment Index
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -213,12 +213,21 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
           tabTranslateAnimatedStyles,
         ]}
       />
-      {segments.map((segment, index) => {
+      {memoizedSegments.map((segment, index) => {
+        const isSelected = currentIndex === index;
+        const { label, ...accessibilityProps } = segment;
+
         return (
           <Pressable
             onPress={() => memoizedTabPressCallback(index)}
             key={index}
             style={[styles.touchableContainer, pressableWrapper]}
+            accessibilityState={{ selected: isSelected }}
+            accessibilityHint={!isSelected ? `Selects ${label} option` : ''}
+            accessibilityLabel={`${label}, option, ${index + 1} of ${
+              segments.length
+            }`}
+            accessibilityRole="button"
           >
             <View style={styles.textWrapper}>
               <Text
@@ -228,7 +237,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
                     : finalisedInActiveTextStyle,
                 ]}
               >
-                {segment}
+                {label}
               </Text>
               {badgeValues[index] && (
                 <View


### PR DESCRIPTION
This PR is based on the conversation in #31.

Since no new PR was added, and that PR was not updated, this one finishes the implementation started in that PR.

## Changes
- Export `SegmentedControlProps` interface
- Added `Segment` interface
- Changed `segments` from an array of strings to a mixed array of strings and Segment objects
- Transforming `segments` prop into an array of Segment objects and memoizing it. This keeps backwards compatibility by allowing a full array of strings to be passed
- Setting default accessibility values in each segment Pressable
- Overriding the default accessibility values by spreading the remaining Segment accessibility values for each segment, if defined