### PR TITLE
feat: added `renderTile` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,29 @@ Make sure you have [React Native Reanimated](https://docs.swmansion.com/react-na
 
 ## :wrench: Props
 
-| Name                    | Description                                    | Required | Type      | Default  |
-| ----------------------- | ---------------------------------------------- | -------- | --------- | -------- |
-| segments                | An array of labels for segments                | YES      | Array     | []       |
-| currentIndex            | Index for the currently active segment         | YES      | Number    | 0        |
-| onChange                | A callback Function with pressed segment index | YES      | Function  | () => {} |
-| badgeValues             | An array of badge value for segments.          | NO       | Array     | []       |
-| isRTL                   | Controls the toggle animation direction        | NO       | Boolean   | false    |
-| containerMargin         | The value used to determine the width          | NO       | Number    | 16       |
-| activeTextStyle         | active text styles                             | NO       | TextStyle | {}       |
-| inactiveTextStyle       | inactive text styles.                          | NO       | TextStyle | {}       |
-| segmentedControlWrapper | Style object for the Segmented Control.        | NO       | ViewStyle | {}       |
-| pressableWrapper        | Style object for the Pressable Container       | NO       | ViewStyle | {}       |
-| tileStyle               | Style object for the Absolute positioned tile  | NO       | ViewStyle | {}       |
-| activeBadgeStyle        | Active Badge Style                             | NO       | ViewStyle | {}       |
-| inactiveBadgeStyle      | Inactive Badge Style                           | NO       | ViewStyle | {}       |
-| badgeTextStyle          | Badge text styles                              | NO       | TextStyle | {}       |
+| Name                    | Description                                    | Required | Type      | Default   |
+| ----------------------- | ---------------------------------------------- | -------- | --------- | --------  |
+| segments                | An array of labels for segments                | YES      | Array     | []        |
+| currentIndex            | Index for the currently active segment         | YES      | Number    | 0         |
+| onChange                | A callback Function with pressed segment index | YES      | Function  | () => {}  |
+| badgeValues             | An array of badge value for segments.          | NO       | Array     | []        |
+| isRTL                   | Controls the toggle animation direction        | NO       | Boolean   | false     |
+| containerMargin         | The value used to determine the width          | NO       | Number    | 16        |
+| activeTextStyle         | active text styles                             | NO       | TextStyle | {}        |
+| inactiveTextStyle       | inactive text styles.                          | NO       | TextStyle | {}        |
+| segmentedControlWrapper | Style object for the Segmented Control.        | NO       | ViewStyle | {}        |
+| pressableWrapper        | Style object for the Pressable Container       | NO       | ViewStyle | {}        |
+| tileStyle               | Style object for the Absolute positioned tile  | NO       | ViewStyle | {}        |
+| activeBadgeStyle        | Active Badge Style                             | NO       | ViewStyle | {}        |
+| inactiveBadgeStyle      | Inactive Badge Style                           | NO       | ViewStyle | {}        |
+| badgeTextStyle          | Badge text styles                              | NO       | TextStyle | {}        |
+| renderTile              | Render a custom tile component                 | NO       | Function  | undefined |
 
 > :warning: all View styles or Text Styles passed as props overrides some default styles provided by the package. Make sure you use it properly :)
 
 > :information_source: To apply your own `shadowStyles` use the tileStyle prop
+
+> :information_source: `renderTile` takes a function with `style`, `transform` and `width`. You can use these to style your custom tile to look the same as the default style (e.g. if you just wanted to change the animation)
 
 ## :mag: Usage
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,6 +123,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
   activeBadgeStyle,
   inactiveBadgeStyle,
   badgeTextStyle,
+  renderTile,
 }: SegmentedControlProps) => {
   const width = widthPercentageToDP('100%') - containerMargin * 2;
   const translateValue = width / segments.length;
@@ -190,22 +191,40 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
     ...badgeTextStyle,
   };
 
+  const flattenedTileStyle: ViewStyle = StyleSheet.flatten<ViewStyle>([
+    styles.movingSegmentStyle,
+    defaultShadowStyle,
+    StyleSheet.absoluteFill,
+    {
+      width: width / segments.length - 4,
+    },
+    tileStyle,
+  ]);
+
+  const memoizedTile = React.useMemo<React.ReactNode>(() => {
+    if (renderTile) {
+      return renderTile({
+        style: flattenedTileStyle,
+        transform: tabTranslateAnimatedStyles.transform,
+        width: translateValue,
+      });
+    }
+
+    return (
+      <Animated.View style={[flattenedTileStyle, tabTranslateAnimatedStyles]} />
+    );
+  }, [
+    flattenedTileStyle,
+    renderTile,
+    tabTranslateAnimatedStyles,
+    translateValue,
+  ]);
+
   return (
     <Animated.View
       style={[styles.defaultSegmentedControlWrapper, segmentedControlWrapper]}
     >
-      <Animated.View
-        style={[
-          styles.movingSegmentStyle,
-          defaultShadowStyle,
-          tileStyle,
-          StyleSheet.absoluteFill,
-          {
-            width: width / segments.length - 4,
-          },
-          tabTranslateAnimatedStyles,
-        ]}
-      />
+      {memoizedTile}
       {segments.map((segment, index) => {
         return (
           <Pressable

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,15 @@ import Animated, {
 } from 'react-native-reanimated';
 import { widthPercentageToDP } from 'react-native-responsive-screen';
 
+export interface TileProps {
+  /** Styles of the default tile */
+  style: ViewStyle;
+  /** The React Native Reanimated transform style with translateX */
+  transform: ViewStyle['transform'];
+  /** The full width of tile */
+  width: number;
+}
+
 interface SegmentedControlProps {
   /**
    * The Segments Text Array
@@ -72,6 +81,10 @@ interface SegmentedControlProps {
    * Badge Text Styles
    */
   badgeTextStyle?: TextStyle;
+  /**
+   * Render a custom tile component
+   */
+  renderTile?: (props: TileProps) => React.ReactNode;
 }
 
 const defaultShadowStyle = {


### PR DESCRIPTION
## Motivation

We're using this component as a Tab Bar for React Navigation. We wanted to make use of the `position` animated value that React Navigation provides, but you can't interop React Native animated values with React Native Reanimated, and we also couldn't override the translation style anyway.

The best solution we found is to add a custom `renderTile` prop. This way we can render the tile in a React Native `Animated.View`, use the default styles for the tile, but change the translate.

## Changes
This PR adds a `renderTile` prop that allows for rendering a completely custom tile, instead of the default one.

`renderTile` takes a function with the default tile styles, the animated transform style and the tile width as arguments, and returns a custom `ReactNode` to render.

If this prop is not supplied, we just render the same tile we were rendering before.

## Preview

This is an example of what this prop allows you to do. We can use the `position` animated value from `@react-navigation/material-top-tabs` to translate the tile in sync with React Navigation, as you're swiping through each tab.


https://user-images.githubusercontent.com/8539174/166950854-95278be0-a781-48eb-891e-41a69fea8751.mp4